### PR TITLE
Upload from Google Drive 

### DIFF
--- a/cloud-upload-apis/credentials/google-drive.json
+++ b/cloud-upload-apis/credentials/google-drive.json
@@ -1,0 +1,2 @@
+This is a dummy file.
+Replace this file with your own credentials file from [console.developers.google.com] for Google Drive API V3

--- a/cloud-upload-apis/tokens/dummy.pickle
+++ b/cloud-upload-apis/tokens/dummy.pickle
@@ -1,0 +1,2 @@
+This is a dummy token file.
+All the token files for users will be stored in this directory in a pattern of "googleDrive<userID>.pickle"

--- a/config/routes.json
+++ b/config/routes.json
@@ -26,6 +26,12 @@
     "handlers":[
       {"function":"proxyHandler", "args": ["http://ca-load:4000/"]}
     ]
+  },{
+    "method":"use",
+    "route": "/googleAuth/",
+    "handlers":[
+      {"function":"proxyHandler", "args": ["http://ca-load:4001/"]}
+    ]
   },
 
   {

--- a/develop.yml
+++ b/develop.yml
@@ -48,3 +48,4 @@ services:
     container_name: ca-load
     volumes:
       - ./images/:/images/
+      - ./cloud-upload-apis/:/cloud-upload-apis/


### PR DESCRIPTION
This works with [caMicroscope #467](https://github.com/camicroscope/caMicroscope/pull/467) and [SlideLoader #40](https://github.com/camicroscope/SlideLoader/pull/40)

## Description
- A new directory `cloud-upload-apis` is created in with two subdirectories `credentials` and `tokens`.
- `credentials` will be having a `google-drive.json` file containing the user credentials for google drive api.
- `tokens` will be having user specific token files so that once user has completed authentication they don't have to do it again.
- A new `/googleAuth` route is added at `ca-load:4001` to allow user to access authentication URL.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
