### PR TITLE
Fda/htt Change the location of the images folder

### DIFF
--- a/caMicroscope.yml
+++ b/caMicroscope.yml
@@ -27,13 +27,14 @@ services:
       - mongo
   back:
     build:
-      context: "https://github.com/camicroscope/caracal.git#fda/htt"
+      context: "https://github.com/caMicroscope/caracal.git#fda/htt"
       args:
         viewer: "fda/htt"
+        fork: "caMicroscope"
     depends_on:
       - "mongo"
     ports:
-      - "4010:4010"
+      - "443:4010"
     container_name: ca-back
     restart: always
     logging:
@@ -41,7 +42,7 @@ services:
           max-file: "5"
           max-size: "10m"
     volumes:
-      - /labs/sharmalab/HTT_IMGS/:/images/
+      - C:/Users/Phoebe.Qian/Documents/whole_slide/:/images/
       - ./config/login.html:/src/static/login.html
       - ./jwt_keys/:/src/keys/
       - ./config/routes.json:/src/routes.json
@@ -52,6 +53,7 @@ services:
       MONGO_URI: "mongodb://ca-mongo"
       DISABLE_TF: "true"
       ALLOW_PUBLIC: "true"
+      DISABLE_SEC: "true"
   iip:
     image: camicroscope/iipimage:version-3.8.4
     container_name: ca-iip
@@ -61,7 +63,7 @@ services:
           max-size: "10m"
     restart: always
     volumes:
-      - /labs/sharmalab/HTT_IMGS/:/images/
+      - C:/Users/Phoebe.Qian/Documents/whole_slide/:/images/
   loader:
     build: "https://github.com/camicroscope/SlideLoader.git#v3.9.8"
     container_name: ca-load
@@ -71,4 +73,4 @@ services:
           max-file: "5"
           max-size: "10m"
     volumes:
-      - /labs/sharmalab/HTT_IMGS/:/images/
+      - C:/Users/Phoebe.Qian/Documents/whole_slide/:/images/

--- a/caMicroscope.yml
+++ b/caMicroscope.yml
@@ -27,14 +27,14 @@ services:
       - mongo
   back:
     build:
-      context: "https://github.com/caMicroscope/caracal.git#fda/htt"
+      context: "https://github.com/camicroscope/caracal.git#fda/htt"
       args:
         viewer: "fda/htt"
-        fork: "caMicroscope"
+        fork: "camicroscope"
     depends_on:
       - "mongo"
     ports:
-      - "443:4010"
+      - "4010:4010"
     container_name: ca-back
     restart: always
     logging:
@@ -42,7 +42,7 @@ services:
           max-file: "5"
           max-size: "10m"
     volumes:
-      - C:/Users/Phoebe.Qian/Documents/whole_slide/:/images/
+      - ./images/:/images/
       - ./config/login.html:/src/static/login.html
       - ./jwt_keys/:/src/keys/
       - ./config/routes.json:/src/routes.json
@@ -63,7 +63,7 @@ services:
           max-size: "10m"
     restart: always
     volumes:
-      - C:/Users/Phoebe.Qian/Documents/whole_slide/:/images/
+      - ./images/:/images/
   loader:
     build: "https://github.com/camicroscope/SlideLoader.git#v3.9.8"
     container_name: ca-load
@@ -73,4 +73,4 @@ services:
           max-file: "5"
           max-size: "10m"
     volumes:
-      - C:/Users/Phoebe.Qian/Documents/whole_slide/:/images/
+      - ./images/:/images/

--- a/caMicroscope.yml
+++ b/caMicroscope.yml
@@ -1,6 +1,18 @@
 version: '3'
 
 services:
+  e2e_tests:
+    image: ubuntu:14.04
+    depends_on:
+      - web
+    command: 'nc -vz web 8080'
+  web:
+    image: ubuntu:14.04
+    command: >
+      /bin/bash -c "
+        sleep 5;
+        nc -lk 0.0.0.0 8080;
+      "
   mongo:
     image: mongo:4.2-bionic
     container_name: ca-mongo
@@ -74,3 +86,16 @@ services:
           max-size: "10m"
     volumes:
       - ./images/:/images/
+  start_dependencies:
+    image: ubuntu:14.04
+    depends_on:
+      - web
+    command: >
+      /bin/bash -c "
+        while ! nc -z web 8080;
+        do
+          echo sleeping;
+          sleep 1;
+        done;
+        echo Connected!;
+      "

--- a/caMicroscope.yml
+++ b/caMicroscope.yml
@@ -1,18 +1,6 @@
 version: '3'
 
 services:
-  e2e_tests:
-    image: ubuntu:14.04
-    depends_on:
-      - web
-    command: 'nc -vz web 8080'
-  web:
-    image: ubuntu:14.04
-    command: >
-      /bin/bash -c "
-        sleep 5;
-        nc -lk 0.0.0.0 8080;
-      "
   mongo:
     image: mongo:4.2-bionic
     container_name: ca-mongo
@@ -86,16 +74,3 @@ services:
           max-size: "10m"
     volumes:
       - ./images/:/images/
-  start_dependencies:
-    image: ubuntu:14.04
-    depends_on:
-      - web
-    command: >
-      /bin/bash -c "
-        while ! nc -z web 8080;
-        do
-          echo sleeping;
-          sleep 1;
-        done;
-        echo Connected!;
-      "


### PR DESCRIPTION
## Summary
We are asking for a very few changes. We want to change the location of the images folder.
* Old: /labs/sharmalab/HTT_IMGS/
* New: ./images

## Motivation
We want to delete Phoebe's fork. This is the only change she made. We want this change in the camicroscope fork of fda/htt.

## Testing
I can't test this change because the fda/htt branch currently cannot move past the registration module as discussed here https://github.com/DIDSR/HTTdev/issues/100#issuecomment-1243039233.

The infinite loop happens when I install https://github.com/camicroscope/Distro and when I install from https://github.com/phoebe-qian/Distro

Another problem is that gmail is still being used in the authentication at the beginning when I install https://github.com/camicroscope/Distro. We don't want google involved anywhere.

## Questions
