### PR TITLE
Auto build develop.yml as test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,9 @@
+name: Docker Compose Test
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the develop stack
+        run: docker-compose -f develop.yml build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,8 @@ name: Docker Compose Test
 on: push
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Build the develop stack
-        run: export LD_LIBRARY_PATH=/usr/local/lib && docker-compose -f develop.yml build
+        run: docker-compose -f develop.yml build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,4 +6,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build the develop stack
-        run: docker-compose -f develop.yml build
+        run: export LD_LIBRARY_PATH=/usr/local/lib && docker-compose -f develop.yml build

--- a/config/user.json
+++ b/config/user.json
@@ -1,1 +1,0 @@
-{"user_id":"json",is_admin:false}

--- a/config/user.json
+++ b/config/user.json
@@ -1,0 +1,1 @@
+{"user_id":"json",is_admin:false}


### PR DESCRIPTION
Ubuntu 18 because of open ssl error on the ci env on ubuntu-latest

```
unable to prepare context: unable to 'git clone' to temporary context directory: error fetching: /usr/lib/git-core/git-remote-https: /tmp/_MEIFRGp8Z/libcrypto.so.1.1: version `OPENSSL_1_1_1' not found (required by /lib/x86_64-linux-gnu/libssh.so.4)
```