### PR TITLE
For 3.12.0

### DIFF
--- a/caMicroscope.yml
+++ b/caMicroscope.yml
@@ -13,9 +13,9 @@ services:
       - ./db:/data/db
   back:
     build:
-      context: "https://github.com/camicroscope/caracal.git#v3.11.0"
+      context: "https://github.com/camicroscope/caracal.git#v3.11.1"
       args:
-        viewer: "v3.11.0"
+        viewer: "v3.11.1"
     depends_on:
       - "mongo"
     ports:

--- a/caMicroscope.yml
+++ b/caMicroscope.yml
@@ -13,9 +13,9 @@ services:
       - ./db:/data/db
   back:
     build:
-      context: "https://github.com/camicroscope/caracal.git#v3.11.0"
+      context: "https://github.com/camicroscope/caracal.git#v3.12.0"
       args:
-        viewer: "v3.11.0"
+        viewer: "v3.12.0"
     depends_on:
       - "mongo"
     ports:
@@ -49,7 +49,7 @@ services:
     volumes:
       - ./images/:/images/
   loader:
-    build: "https://github.com/camicroscope/SlideLoader.git#v3.11.0"
+    build: "https://github.com/camicroscope/SlideLoader.git#v3.12.0"
     container_name: ca-load
     restart: always
     logging:
@@ -65,7 +65,7 @@ services:
     build:
       context: "https://github.com/camicroscope/dicomsrv.git#v3.11.1"
       args: 
-        indexer: "v3.11.0"
+        indexer: "v3.12.0"
     container_name: ca-dicomsrv
     restart: unless-stopped
     stdin_open: true

--- a/caMicroscope.yml
+++ b/caMicroscope.yml
@@ -13,9 +13,9 @@ services:
       - ./db:/data/db
   back:
     build:
-      context: "https://github.com/camicroscope/caracal.git#v3.11.1"
+      context: "https://github.com/camicroscope/caracal.git#v3.11.0"
       args:
-        viewer: "v3.11.1"
+        viewer: "v3.11.0"
     depends_on:
       - "mongo"
     ports:
@@ -62,7 +62,10 @@ services:
       DICOM_PORT: "11112"
       DICOM_UI_PORT: "8042"
   dicomsrv:
-    build: "https://github.com/camicroscope/dicomsrv.git#v3.11.0"
+    build:
+      context: "https://github.com/camicroscope/dicomsrv.git#v3.11.1"
+      args: 
+        indexer: "v3.11.0"
     container_name: ca-dicomsrv
     restart: unless-stopped
     stdin_open: true

--- a/caMicroscope.yml
+++ b/caMicroscope.yml
@@ -13,9 +13,9 @@ services:
       - ./db:/data/db
   back:
     build:
-      context: "https://github.com/camicroscope/caracal.git#v3.10.2"
+      context: "https://github.com/camicroscope/caracal.git#v3.11.0"
       args:
-        viewer: "v3.10.2"
+        viewer: "v3.11.0"
     depends_on:
       - "mongo"
     ports:
@@ -39,7 +39,7 @@ services:
       DISABLE_SEC: "true"
       GENERATE_KEY_IF_MISSING: "true"
   iip:
-    image: camicroscope/iipimage:version-3.10.2
+    image: camicroscope/iipimage:version-3.11.0
     container_name: ca-iip
     logging:
       options:
@@ -49,7 +49,7 @@ services:
     volumes:
       - ./images/:/images/
   loader:
-    build: "https://github.com/camicroscope/SlideLoader.git#v3.10.2"
+    build: "https://github.com/camicroscope/SlideLoader.git#v3.11.0"
     container_name: ca-load
     restart: always
     logging:
@@ -62,7 +62,7 @@ services:
       DICOM_PORT: "11112"
       DICOM_UI_PORT: "8042"
   dicomsrv:
-    build: "https://github.com/camicroscope/dicomsrv.git"
+    build: "https://github.com/camicroscope/dicomsrv.git#v3.11.0"
     container_name: ca-dicomsrv
     restart: unless-stopped
     stdin_open: true

--- a/config/contentSecurityPolicy.json
+++ b/config/contentSecurityPolicy.json
@@ -17,6 +17,10 @@
   "cdn.datatables.net",
   "maxcdn.bootstrapcdn.com"
 ],
+"connectSrc": [
+  "'self'",
+  "*"
+],
 "styleSrc": [
   "'self'",
   "'unsafe-inline'",

--- a/config/routes.json
+++ b/config/routes.json
@@ -117,6 +117,12 @@
       {"function":"mongoFind", "args": ["camic", "mark"]}
     ]
   },{
+    "route":"/data/Mark/count",
+    "method":"get",
+    "handlers":[
+      {"function":"mongoCount", "args": ["camic", "mark"]}
+    ]
+  },{
     "route":"/data/Mark/post",
     "method":"post",
     "handlers":[
@@ -146,6 +152,12 @@
     "method":"get",
     "handlers":[
       {"function":"mongoDistinct", "args": ["camic", "mark", "provenance.analysis"]}
+    ]
+  },{
+    "route":"/data/Mark/provenances",
+    "method":"get",
+    "handlers":[
+      {"function":"mongoDistinct", "args": ["camic", "mark", "provenance"]}
     ]
   },{
     "route":"/data/Mark/multi",

--- a/config/routes.json
+++ b/config/routes.json
@@ -114,7 +114,7 @@
     "route":"/data/Mark/find",
     "method":"get",
     "handlers":[
-      {"function":"mongoFind", "args": ["camic", "mark"]}
+      {"function":"mongoPaginatedFind", "args": ["camic", "mark"]}
     ]
   },{
     "route":"/data/Mark/count",

--- a/develop.yml
+++ b/develop.yml
@@ -44,8 +44,7 @@ services:
       DICOM_PORT: "11112"
       DICOM_UI_PORT: "8042"
   dicomsrv:
-    build: 
-      context: "https://github.com/camicroscope/dicomsrv.git"
+    build: "https://github.com/camicroscope/dicomsrv.git"
     container_name: ca-dicomsrv
     restart: unless-stopped
     stdin_open: true

--- a/develop.yml
+++ b/develop.yml
@@ -16,7 +16,9 @@ services:
       - "mongo"
     ports:
       - "4010:4010"
+      - "9229:9229"
     container_name: ca-back
+    command: node --inspect=0.0.0.0:9229 --prof caracal.js
     volumes:
       - ./config/login.html:/src/static/login.html
       - ./jwt_keys/:/src/keys/
@@ -28,6 +30,7 @@ services:
       MONGO_URI: "mongodb://ca-mongo"
       DISABLE_SEC: "true"
       ALLOW_PUBLIC: "true"
+      NUM_THREADS: 1
   iip:
     build: "https://github.com/camicroscope/iipImage.git#develop"
     container_name: ca-iip

--- a/develop.yml
+++ b/develop.yml
@@ -44,7 +44,8 @@ services:
       DICOM_PORT: "11112"
       DICOM_UI_PORT: "8042"
   dicomsrv:
-    build: "https://github.com/camicroscope/dicomsrv.git"
+    build: 
+      context: "https://github.com/camicroscope/dicomsrv.git"
     container_name: ca-dicomsrv
     restart: unless-stopped
     stdin_open: true

--- a/kc_caMicroscope.yml
+++ b/kc_caMicroscope.yml
@@ -51,9 +51,9 @@ services:
       - ./db:/data/db
   back:
     build:
-      context: "https://github.com/camicroscope/caracal.git#v3.10.0"
+      context: "https://github.com/camicroscope/caracal.git#v3.11.1"
       args:
-        viewer: "v3.10.1"
+        viewer: "v3.11.1"
     depends_on:
       - "mongo"
     ports:
@@ -76,7 +76,7 @@ services:
       MONGO_URI: "mongodb://ca-mongo"
       GENERATE_KEY_IF_MISSING: "true"
   iip:
-    image: camicroscope/iipimage:version-3.10.2
+    image: camicroscope/iipimage:version-3.11.0
     container_name: ca-iip
     logging:
       options:
@@ -86,7 +86,7 @@ services:
     volumes:
       - ./images/:/images/
   loader:
-    build: "https://github.com/camicroscope/SlideLoader.git#v3.10.0"
+    build: "https://github.com/camicroscope/SlideLoader.git#v3.11.0"
     container_name: ca-load
     restart: always
     logging:
@@ -95,3 +95,23 @@ services:
           max-size: "10m"
     volumes:
       - ./images/:/images/
+    environment:
+      DICOM_PORT: "11112"
+      DICOM_UI_PORT: "8042"
+  dicomsrv:
+    build: "https://github.com/camicroscope/dicomsrv.git#v3.11.0"
+    container_name: ca-dicomsrv
+    restart: unless-stopped
+    stdin_open: true
+    tty: true
+    ports:
+      - "8042:8042"
+      - "11112:11112"
+    volumes:
+      - ./jwt_keys/:/root/keys/
+      - ./images/:/images/
+      - ./config/OrthancConfiguration.json:/root/src/Configuration.json
+    environment:
+      DICOM_PORT: "11112"
+      DICOM_UI_PORT: "8042"
+      CARACAL_BACK_HOST_PORT: "ca-back:4010"

--- a/kc_caMicroscope.yml
+++ b/kc_caMicroscope.yml
@@ -51,9 +51,9 @@ services:
       - ./db:/data/db
   back:
     build:
-      context: "https://github.com/camicroscope/caracal.git#v3.11.1"
+      context: "https://github.com/camicroscope/caracal.git#v3.12.0"
       args:
-        viewer: "v3.11.1"
+        viewer: "v3.12.0"
     depends_on:
       - "mongo"
     ports:
@@ -86,7 +86,7 @@ services:
     volumes:
       - ./images/:/images/
   loader:
-    build: "https://github.com/camicroscope/SlideLoader.git#v3.11.0"
+    build: "https://github.com/camicroscope/SlideLoader.git#v3.12.0"
     container_name: ca-load
     restart: always
     logging:
@@ -99,7 +99,7 @@ services:
       DICOM_PORT: "11112"
       DICOM_UI_PORT: "8042"
   dicomsrv:
-    build: "https://github.com/camicroscope/dicomsrv.git#v3.11.0"
+    build: "https://github.com/camicroscope/dicomsrv.git#v3.11.1"
     container_name: ca-dicomsrv
     restart: unless-stopped
     stdin_open: true

--- a/quip-pathdb.yml
+++ b/quip-pathdb.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ./db:/data/db
   iip:
-    image: camicroscope/iipimage:version-3.10.2
+    image: camicroscope/iipimage:version-3.11.0
     container_name: ca-iip
     restart: unless-stopped
     volumes:

--- a/quip-pathdb.yml
+++ b/quip-pathdb.yml
@@ -15,9 +15,9 @@ services:
       - ./images/:/data/images/
   back:
     build:
-      context: "https://github.com/camicroscope/caracal.git#v3.11.0"
+      context: "https://github.com/camicroscope/caracal.git#v3.11.1"
       args:
-        viewer: "v3.11.0"
+        viewer: "v3.11.1"
     depends_on:
       - "mongo"
     ports:
@@ -37,7 +37,7 @@ services:
     build:
       context: "https://github.com/SBU-BMI/PathDB.git#2.0.0"
       args:
-        viewer: "v3.11.0"
+        viewer: "v3.11.1"
     container_name: quip-pathdb
     restart: unless-stopped
     ports: ["443:443","80:80"]

--- a/quip-pathdb.yml
+++ b/quip-pathdb.yml
@@ -15,9 +15,9 @@ services:
       - ./images/:/data/images/
   back:
     build:
-      context: "https://github.com/camicroscope/caracal.git#v3.11.1"
+      context: "https://github.com/camicroscope/caracal.git#v3.12.0"
       args:
-        viewer: "v3.11.1"
+        viewer: "v3.12.0"
     depends_on:
       - "mongo"
     ports:

--- a/quip-pathdb.yml
+++ b/quip-pathdb.yml
@@ -61,7 +61,7 @@ services:
     volumes:
       - ./data:/data
   heatmaploader:
-    build: "https://github.com/SBU-BMI/uploadHeatmaps.git#v1.5.4"
+    build: "https://github.com/SBU-BMI/uploadHeatmaps.git#v1.5.5"
     container_name: quip-hmloader
     volumes:
       - ./data:/mnt/data/


### PR DESCRIPTION
# Distro
* Bump tags for viewer and backend to 3.12.0
* Add dicom support to keycloak deployment option
* Add chrome tools node debug profiling

# Caracal (backend service)
* Fix pathdb handle files with url unsafe iip files (https://github.com/camicroscope/Distro/issues/215)
* Check for either mongo binary (https://github.com/camicroscope/caracal/#169)
* Add paginated find
* Add count handler

# Slideloader
* Hotfix for openslide on ARM systems
* DICOM annotation and API routes and utilities

# Viewer
### Accessibility and Standards Compliance

- Created GitHub workflow for accessibility checks
- Jest test for DrawerHelper JS
- Various HTML pages updated to comply with W3C standards

### UI/UX Improvements and Fixes

- Adjustments for mobile view (e.g., overflow table scroll, button UI improvements)
- Enhanced responsiveness (e.g., Workbench HTML page, option dropdown UI)
- Clarity improvements (e.g., clearer instructions, fixing overlapping buttons)
- Loader addition and UI adjustments
- Transitioned from Google Form to GitHub issue link for feedback

### Feature Additions and Enhancements

- Added Aria Labels to Image Links
- Added go back button and meta tag
- Improved signup page user experience and consistency
- Improved Slides Page Layout and User Guidance
- (Secret) dicom connect demo

### Bug Fixes and Error Handling

- Fixed disabled zooming in mobile view
- Fixed various linting errors and tile loading issues

### Code Refactoring and Maintenance

- Refactoring for improved footer reusability component
- Improved config handling and file organization


